### PR TITLE
Updated color pallet for App

### DIFF
--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/EpgSurfaceView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/EpgSurfaceView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -18,6 +19,7 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.spark.fastplayer.ui.theme.TextColor
 import kotlin.math.ln
 
 
@@ -25,8 +27,8 @@ import kotlin.math.ln
 fun EPGCardItemSurface(
     modifier: Modifier = Modifier,
     shape: Shape = RectangleShape,
-    color: Color = Color.Black,
-    contentColor: Color = Color.Gray,
+    color: Color = MaterialTheme.colorScheme.primary,
+    contentColor: Color = MaterialTheme.colorScheme.secondary,
     border: BorderStroke? = null,
     elevation: Dp = 0.dp,
     content: @Composable () -> Unit
@@ -61,5 +63,5 @@ private fun Color.withElevation(elevation: Dp): Color {
 
 private fun calculateForeground(elevation: Dp): Color {
     val alpha = ((4.5f * ln(elevation.value + 1)) + 2f) / 100f
-    return Color.White.copy(alpha = alpha)
+    return TextColor.copy(alpha = alpha)
 }

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/HomeScreen.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/HomeScreen.kt
@@ -50,7 +50,7 @@ fun HomeScreen(
                 sheetState = modalSheetState,
                 sheetContent = { BottomSheetLayout(bottomSheetDataState.value) },
                 sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-                scrimColor = Color.Black.copy(alpha = 0.4f),
+                scrimColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
             ) {
                 Column {
                     RenderPlayer(playbackState = playbackState)
@@ -100,7 +100,7 @@ fun showLoading(ePGState: EPGState) {
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
                     .size(100.dp)
-                    .background(Color.DarkGray, shape = RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surface, shape = RoundedCornerShape(8.dp))
             ) {
                 /*TO DO */
                 //current theme doesn't support loading indicator
@@ -119,17 +119,17 @@ fun RenderPlayer(playbackState: MutableState<PlaybackState>) {
         Configuration.ORIENTATION_LANDSCAPE ->  {
             systemUiController.isSystemBarsVisible = false
             systemUiController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            Modifier.background(color = Color.Black).wrapContentSize()
+            Modifier.background(color = MaterialTheme.colorScheme.primary).wrapContentSize()
         }
         else -> {
             systemUiController.isSystemBarsVisible = true
-            Modifier.background(color = Color.Black).fillMaxHeight(0.28f).fillMaxWidth()
+            Modifier.background(color = MaterialTheme.colorScheme.primary).fillMaxHeight(0.28f).fillMaxWidth()
         }
     }
     if (playbackState.value is PlaybackState.PlaybackSuccess) {
         Surface(
             modifier = modifier
-                .background(Color.Black)
+                .background(MaterialTheme.colorScheme.primary)
                 .fillMaxSize()
         ) {
             VideoPlayerWidget(playbackState = playbackState.value)

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/ProgramInfoPopup.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/ProgramInfoPopup.kt
@@ -3,10 +3,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -20,6 +20,8 @@ import com.spark.fastplayer.common.getFormattedScheduledTime
 import com.spark.fastplayer.common.getStreamType
 import com.spark.fastplayer.presentation.epg.StreamType
 import com.spark.fastplayer.presentation.epg.ui.BottomSheetDataState
+import com.spark.fastplayer.ui.theme.LiveBadgeColor
+import com.spark.fastplayer.ui.theme.UpcomingBadgeColor
 import org.openapitools.client.models.Program
 
 @Composable
@@ -37,7 +39,7 @@ fun SheetContent(program: Program) {
         modifier = Modifier
             .height(280.dp)
             .fillMaxWidth()
-            .background(Color.DarkGray)
+            .background(MaterialTheme.colorScheme.surface)
             .padding(start = 12.dp, end = 12.dp),
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.SpaceEvenly
@@ -64,14 +66,14 @@ fun SheetContent(program: Program) {
 
             Box(
                 modifier = Modifier
-                    .border(width = 0.dp, color = Color.White, shape = RoundedCornerShape(5.dp))
-                    .background(if (streamTye is StreamType.Live) Color.Red else Color.Blue)
+                    .border(width = 0.dp, color = MaterialTheme.colorScheme.onPrimary, shape = RoundedCornerShape(5.dp))
+                    .background(if (streamTye is StreamType.Live) LiveBadgeColor else UpcomingBadgeColor)
                     .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp)
             ) {
                 androidx.compose.material3.Text(
                     text = if (streamTye is StreamType.Live) "Live" else "Upcoming",
                     fontSize = 16.sp,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.End,
                     fontWeight = FontWeight.Bold,
                 )
@@ -83,7 +85,7 @@ fun SheetContent(program: Program) {
             text = program.title.orEmpty(),
             fontWeight = FontWeight.Bold,
             fontSize = 18.sp,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             textAlign = TextAlign.Start,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
@@ -92,7 +94,7 @@ fun SheetContent(program: Program) {
         Text(
             text = program.description.orEmpty(),
             fontSize = 14.sp,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             textAlign = TextAlign.Start,
             maxLines = 3,
             overflow = TextOverflow.Ellipsis
@@ -101,7 +103,7 @@ fun SheetContent(program: Program) {
         Text(
             text = program.getFormattedScheduledTime(),
             fontSize = 18.sp,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             textAlign = TextAlign.Start,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
@@ -109,14 +111,14 @@ fun SheetContent(program: Program) {
 
         Box(
             modifier = Modifier
-                .border(width = 0.dp, color = Color.White, shape = RoundedCornerShape(4.dp))
-                .background(Color.Black)
+                .border(width = 0.dp, color = MaterialTheme.colorScheme.onPrimary, shape = RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.primary)
                 .padding(8.dp)
         ) {
             androidx.compose.material3.Text(
                 text = program.channel?.taxonomies?.firstOrNull()?.title.orEmpty(),
                 fontSize = 16.sp,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
                 textAlign = TextAlign.End,
                 fontWeight = FontWeight.Bold,
             )

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/EPGView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/EPGView.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -98,7 +98,7 @@ private fun RenderEPGRowsCollections(
                             .padding(12.dp),
                         fontWeight = FontWeight.Bold,
                         fontSize = 20.sp,
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                         textAlign = TextAlign.Center,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/TaxonomyRowView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/TaxonomyRowView.kt
@@ -29,7 +29,7 @@ fun EpgTaxonomyCollection(
 ) {
     LazyRow(
         modifier = modifier,
-        contentPadding = PaddingValues( end = 12.dp)
+        contentPadding = PaddingValues( start = 8.dp , end = 12.dp)
     ) {
         itemsIndexed(taxonomyList) { _, taxonomy ->
             taxonomy?.title?.let {

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/TaxonomyRowView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/grid/TaxonomyRowView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -75,7 +76,7 @@ fun TaxonomyLabel(
                 text = txName,
                 fontWeight = FontWeight.Bold,
                 fontSize = 16.sp,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
                 textAlign = TextAlign.Center,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/item/ChannelLogoView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/item/ChannelLogoView.kt
@@ -3,17 +3,15 @@ package com.spark.fastplayer.presentation.epg.ui.item
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.spark.fastplayer.R
 import com.spark.fastplayer.presentation.epg.ui.EPGCardItemSurface
 
 @Composable
@@ -24,11 +22,11 @@ fun ChannelLogoView(
     elevation: Dp = 0.dp
 ) {
     EPGCardItemSurface(
-        color = Color.LightGray,
+        color = MaterialTheme.colorScheme.tertiary,
         elevation = elevation,
         shape = RoundedCornerShape(6.dp),
         modifier = modifier,
-        border = BorderStroke(2.dp, Color.White)
+        border = BorderStroke(2.dp, MaterialTheme.colorScheme.onPrimary)
     ) {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
@@ -36,7 +34,6 @@ fun ChannelLogoView(
                 .crossfade(true)
                 .build(),
             contentDescription = contentDescription,
-            placeholder = painterResource(R.drawable.ic_baseline_connected_tv_24),
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Inside,
         )

--- a/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/item/ChannelMetaDataView.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/epg/ui/item/ChannelMetaDataView.kt
@@ -4,11 +4,11 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -17,6 +17,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.spark.fastplayer.presentation.epg.StreamType
 import com.spark.fastplayer.presentation.epg.ui.EPGCardItemSurface
+import com.spark.fastplayer.ui.theme.LiveBadgeColor
+import com.spark.fastplayer.ui.theme.UpcomingBadgeColor
 
 @Composable
 fun ChannelMetaDataView(
@@ -26,10 +28,10 @@ fun ChannelMetaDataView(
     elevation: Dp = 0.dp
 ) {
     EPGCardItemSurface(
-        color = Color.DarkGray,
+        color = MaterialTheme.colorScheme.secondary,
         elevation = elevation,
         shape = RoundedCornerShape(8.dp),
-        border = BorderStroke(1.dp, Color.Gray)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary)
     ) {
 
         Column(
@@ -42,7 +44,7 @@ fun ChannelMetaDataView(
                     text = channelName,
                     fontWeight = FontWeight.Bold,
                     fontSize = 16.sp,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Start,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -56,19 +58,19 @@ fun ChannelMetaDataView(
                 Text(
                     text = broadCastTime,
                     fontSize = 12.sp,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onPrimary,
                     textAlign = TextAlign.Start,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
 
                 Box(modifier  = Modifier
-                    .background(if (streamType is StreamType.Live) Color.Red else Color.Gray)
+                    .background(if (streamType is StreamType.Live) LiveBadgeColor else UpcomingBadgeColor)
                     .padding(1.dp)) {
                     Text(
                         text = if (streamType is StreamType.Live) "Live" else "UpComing",
                         fontSize = 12.sp,
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onPrimary,
                         textAlign = TextAlign.End,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/spark/fastplayer/presentation/player/PlayerWidget.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/player/PlayerWidget.kt
@@ -108,7 +108,7 @@ private fun RenderPlayerView(exoPlayer: ExoPlayer, playbackState: PlayBackMetaDa
             modifier = Modifier
                 .clickable {
                     shouldShowControls = shouldShowControls.not()
-                }
+                }.background(MaterialTheme.colorScheme.primary)
                 .constrainAs(playerView) {},
             factory = {
                 StyledPlayerView(context).apply {

--- a/app/src/main/java/com/spark/fastplayer/presentation/player/PlayerWidget.kt
+++ b/app/src/main/java/com/spark/fastplayer/presentation/player/PlayerWidget.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -109,7 +108,7 @@ private fun RenderPlayerView(exoPlayer: ExoPlayer, playbackState: PlayBackMetaDa
             modifier = Modifier
                 .clickable {
                     shouldShowControls = shouldShowControls.not()
-                }.background(Color.Black)
+                }
                 .constrainAs(playerView) {},
             factory = {
                 StyledPlayerView(context).apply {
@@ -139,7 +138,7 @@ private fun RenderPlayerView(exoPlayer: ExoPlayer, playbackState: PlayBackMetaDa
             enter = fadeIn(),
             exit = fadeOut()
         ) {
-            Box(modifier = Modifier.background(Color.Black.copy(alpha = 0.6f))) {
+            Box(modifier = Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.6f))) {
                 TopControl(
                     modifier = Modifier
                         .align(Alignment.TopStart)
@@ -207,7 +206,7 @@ private fun TopControl(modifier: Modifier = Modifier, playBackMetaData: PlayBack
                 modifier = modifier.padding(start = 16.dp),
                 text = playBackMetaData?.title.orEmpty(),
                 style = MaterialTheme.typography.bodyLarge,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
                 fontWeight = FontWeight.Bold
             )
 
@@ -215,7 +214,7 @@ private fun TopControl(modifier: Modifier = Modifier, playBackMetaData: PlayBack
                 modifier = modifier.padding(start = 16.dp),
                 text = playBackMetaData?.description.orEmpty(),
                 style = MaterialTheme.typography.bodySmall,
-                color = Color.White,
+                color = MaterialTheme.colorScheme.onPrimary,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
@@ -236,8 +235,8 @@ private fun BottomControls(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 16.dp, end = 16.dp),
-            color = Color.White,
-            trackColor = Color.White
+            color = MaterialTheme.colorScheme.onPrimary,
+            trackColor = MaterialTheme.colorScheme.onPrimary
         )
 
 

--- a/app/src/main/java/com/spark/fastplayer/ui/theme/Color.kt
+++ b/app/src/main/java/com/spark/fastplayer/ui/theme/Color.kt
@@ -2,10 +2,12 @@ package com.spark.fastplayer.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val primary = Color.Black
+val secondaryColor = Color.DarkGray
+val tertiary = Color.LightGray
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+val BackgroundColor = Color.Black
+val SurfaceColor = Color.DarkGray
+val TextColor = Color.White
+val LiveBadgeColor = Color.Red
+val UpcomingBadgeColor = Color.Black

--- a/app/src/main/java/com/spark/fastplayer/ui/theme/Color.kt
+++ b/app/src/main/java/com/spark/fastplayer/ui/theme/Color.kt
@@ -10,4 +10,4 @@ val BackgroundColor = Color.Black
 val SurfaceColor = Color.DarkGray
 val TextColor = Color.White
 val LiveBadgeColor = Color.Red
-val UpcomingBadgeColor = Color.Black
+val UpcomingBadgeColor = Color.Blue

--- a/app/src/main/java/com/spark/fastplayer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/spark/fastplayer/ui/theme/Theme.kt
@@ -18,27 +18,25 @@ import androidx.core.view.ViewCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Color.Black,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    background =Color.Black
+    primary = primary,
+    secondary = secondaryColor,
+    tertiary = tertiary,
+    background = BackgroundColor,
+    secondaryContainer = SurfaceColor,
+    surface = SurfaceColor,
+    onPrimary = TextColor,
+    onBackground = BackgroundColor
 )
 
 private val LightColorScheme = lightColorScheme(
     primary = Color.Black,
-    secondary = PurpleGrey40,
-    tertiary = Pink40,
-    background = Color.Black
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    secondary = secondaryColor,
+    tertiary = tertiary,
+    background = Color.Black,
+    secondaryContainer = Color.DarkGray,
+    surface = SurfaceColor,
+    onPrimary = TextColor,
+    onBackground = BackgroundColor,
 )
 
 @Composable


### PR DESCRIPTION
##  Description
- To avoid using direct references of `Color` class,  instead using `Color `defined in our App's `MaterialTheme`
- App should remain consistent in `Light/Dark` mode

## Changes
 -  `Color `added in `Theme.kt`
 -  Wiped out direct references of Color class


##  Test Demo  
![WhatsApp Image 2023-03-28 at 7 18 03 PM](https://user-images.githubusercontent.com/50236871/228318294-2b6340ee-cf03-48a5-bd10-6d02da2cf34d.jpeg)




